### PR TITLE
[Closes #30] Separate attrs that are nodes form the ones that are not

### DIFF
--- a/src/ktn_code.erl
+++ b/src/ktn_code.erl
@@ -48,6 +48,7 @@
 -type tree_node() ::
     #{type => tree_node_type(),
       attrs => map(),
+      node_attrs => map(),
       content => [tree_node()]}.
 
 -exported_type(tree_node/1).


### PR DESCRIPTION
There is a wiki page with more information regarding the rationale behind this change: [Parse Tree Specification (ktn_code)](https://github.com/inaka/erlang-katana/wiki/Parse-Tree-Specification-(ktn_code)).