### PR TITLE
Added an erlang config validation script

### DIFF
--- a/scripts/validate_config
+++ b/scripts/validate_config
@@ -1,0 +1,24 @@
+#!/usr/bin/env escript
+%% -*- erlang -*-
+main([File]) ->
+    try
+        case file:consult(File) of
+            {ok, _} ->
+                io:format("OK~n"),
+                halt(0);
+            {error, Error} ->
+                io:format("~s~n", [file:format_error(Error)]),
+                halt(1)
+        end
+    catch
+        _:Exception ->
+            io:format("error: ~p", [Exception]),
+            usage()
+    end;
+main(_) ->
+    usage().
+
+usage() ->
+    io:format("usage: validate_config FILE~n"),
+    halt(1).
+


### PR DESCRIPTION
This PR adds a a small script to validate erlang configuration files, by calling file:consult/1 on a filename. It's intended use is for operations to be able to check their config files without help from a set of erlang eyeballs. 