### PR TITLE
Improve ktn_os according to the latest changes to os:cmd

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,11 +23,6 @@
 {profiles, [
   {test, [
     {deps, [{xref_runner, "1.0.0"}]}
-  ]},
-  {shell, [
-    {deps, [
-      {sync, {git, "https://github.com/rustyio/sync.git", {ref, "9c78e7b"}}}
-    ]}
   ]}
 ]}.
 
@@ -72,7 +67,3 @@
            , {plt_location, local}
            , {base_plt_apps, [stdlib, kernel]}
            , {base_plt_location, global}]}.
-
-%% == Shell ==
-
-{shell, [{apps, [sync]}]}.


### PR DESCRIPTION
As @getong points out in inaka/apns4erl#157, there is a race condition that was fixed in `os:cmd` [here](https://github.com/erlang/otp/commit/bf9f79e81530b37d5ac4abe1494f270986d92cb4).

We still need `ktn_os:cmd` because we want to find out the exit status code of the command we're running. Therefore, we need to improve `ktn_os:cmd` to deal with the race condition in the same way @garazdawi did for OTP's `os:cmd/1`.