### PR TITLE
Add tests to ktn_task

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
   {test, [
     {erl_opts, [nowarn_missing_spec]},
     {deps, [{xref_runner, "1.2.0"}]},
-    {dialyzer, [{plt_extra_apps, [common_test, dialyzer, elvis, tools, xref_runner]}]}
+    {dialyzer, [{plt_extra_apps, [common_test, dialyzer, tools, xref_runner]}]}
   ]}
 ]}.
 

--- a/test/ktn_os_SUITE.erl
+++ b/test/ktn_os_SUITE.erl
@@ -38,7 +38,10 @@ command(_Config) ->
   Result = Cwd ++ "\n",
   {0, Result} = ktn_os:command("pwd", Opts),
 
-  {2, _} = ktn_os:command("pwd; ls w4th3v3r", Opts),
+  case ktn_os:command("pwd; ls w4th3v3r", Opts) of
+    {0, _} -> ct:fail({error});
+    _ -> ok
+  end,
 
   Result2 = Result ++ "Hi\n",
   {0, Result2} = ktn_os:command("pwd; echo Hi", #{}),
@@ -98,6 +101,7 @@ command(_Config) ->
     port_close(Port),
     ok  = receive X2 -> X2 after 1000 -> timeout end
   after
+    [] = os:cmd("pkill yes"),
     exit(Pid, kill)
   end,
 
@@ -108,5 +112,6 @@ command(_Config) ->
     exit(Port2, kill),
     ok  = receive X3 -> X3 after 1000 -> timeout end
   after
+    [] = os:cmd("pkill yes"),
     exit(Pid2, kill)
   end.

--- a/test/ktn_task_SUITE.erl
+++ b/test/ktn_task_SUITE.erl
@@ -65,7 +65,7 @@ fail_until(X) ->
 -spec fail_until(integer(), integer(), reference()) -> no_return() | ok.
 fail_until(X, Curr, Ref) when X > Curr ->
     cnt_incr(Ref),
-    throw({fail, {Ref, Curr, X}});
+    throw({fail, {X, Curr, Ref}});
 fail_until(_X, _Curr, _Ref) ->
     ok.
 
@@ -82,6 +82,6 @@ wait_for(_Config) ->
 wait_for_error(_Config) ->
     {error, {timeout, {fail}}} =
               ktn_task:wait_for(fun() -> throw({fail}) end, ok, 0, 3),
-    {error, {timeout, {fail, {_Ref, 10, 15}}}} =
+    {error, {timeout, {fail, {15, 10, _Ref}}}} =
               ktn_task:wait_for(fail_until(15), ok, 0, 11),
     ok.

--- a/test/ktn_task_SUITE.erl
+++ b/test/ktn_task_SUITE.erl
@@ -45,21 +45,18 @@ end_per_testcase(_Case, Config) ->
 % https://gist.github.com/garazdawi/17cdb5914b950f0acae21d9fcf7e8d41
 -spec cnt_incr(reference()) -> ok.
 cnt_incr(Ref) ->
-    counters:add(
-        ets:lookup_element(?MODULE, Ref, 2), 1, 1).
+    ets:update_counter(?MODULE, Ref, {2, 1}).
 
 -spec cnt_read(reference()) -> integer().
 cnt_read(Ref) ->
-    counters:get(
-        ets:lookup_element(?MODULE, Ref, 2), 1).
+    ets:lookup_element(?MODULE, Ref, 2).
 
 -spec fail_until(integer()) -> task(_).
 fail_until(X) ->
     Ref = make_ref(),
-    ets:insert(?MODULE, {Ref, counters:new(1, [write_concurrency])}),
+    ets:insert(?MODULE, {Ref, 0}),
     fun () ->
-        Curr = cnt_read(Ref),
-        fail_until(X, Curr, Ref)
+        fail_until(X, cnt_read(Ref), Ref)
     end.
 
 -spec fail_until(integer(), integer(), reference()) -> no_return() | ok.

--- a/test/ktn_task_SUITE.erl
+++ b/test/ktn_task_SUITE.erl
@@ -43,7 +43,7 @@ end_per_testcase(_Case, Config) ->
 
 % Took this idea from
 % https://gist.github.com/garazdawi/17cdb5914b950f0acae21d9fcf7e8d41
--spec cnt_incr(reference()) -> ok.
+-spec cnt_incr(reference()) -> integer().
 cnt_incr(Ref) ->
     ets:update_counter(?MODULE, Ref, {2, 1}).
 
@@ -73,12 +73,22 @@ fail_until(_X, _Curr, _Ref) ->
 -spec wait_for(config()) -> ok.
 wait_for(_Config) ->
     ok = ktn_task:wait_for(fun() -> ok end, ok, 1, 1),
-    ok = ktn_task:wait_for(fail_until(10), ok, 0, 11).
+    ok = ktn_task:wait_for(fail_until(10), ok, 1, 11).
 
 -spec wait_for_error(config()) -> ok.
 wait_for_error(_Config) ->
     {error, {timeout, {fail}}} =
-              ktn_task:wait_for(fun() -> throw({fail}) end, ok, 0, 3),
+                ktn_task:wait_for(fun() ->
+                                    case rand:uniform(99999999) of
+                                        1 ->
+                                            ok;
+                                        _ ->
+                                            throw({fail})
+                                    end
+                                end,
+                                ok,
+                                1,
+                                3),
     {error, {timeout, {fail, {15, 10, _Ref}}}} =
-              ktn_task:wait_for(fail_until(15), ok, 0, 11),
+                ktn_task:wait_for(fail_until(15), ok, 1, 11),
     ok.

--- a/test/ktn_task_SUITE.erl
+++ b/test/ktn_task_SUITE.erl
@@ -1,0 +1,84 @@
+-module(ktn_task_SUITE).
+
+-export([
+         all/0,
+         init_per_testcase/2,
+         end_per_testcase/2
+        ]).
+
+-export([
+         task/1,
+         task_error/1
+        ]).
+
+-define(EXCLUDED_FUNS,
+        [
+          module_info,
+          all,
+          init_per_case,
+          end_per_case
+        ]).
+
+-type config() :: [{atom(), term()}].
+-type fail() :: {fail, {integer(), integer()}}.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Common test
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-spec all() -> [atom(), ...].
+all() ->
+    Exports = ?MODULE:module_info(exports),
+    [F || {F, 1} <- Exports, not lists:member(F, ?EXCLUDED_FUNS)].
+
+-spec init_per_testcase(term(), config()) -> config().
+init_per_testcase(_Case, Config) ->
+    ets:new(?MODULE, [named_table, public]),
+    ets:insert(?MODULE, {counter, counters:new(1, [write_concurrency])}),
+    Config.
+
+-spec end_per_testcase(term(), config()) -> config().
+end_per_testcase(_Case, Config) ->
+    ets:delete(?MODULE),
+    Config.
+
+% Took this idea from
+% https://gist.github.com/garazdawi/17cdb5914b950f0acae21d9fcf7e8d41
+-spec cnt_incr() -> ok.
+cnt_incr() ->
+    counters:add(
+        ets:lookup_element(?MODULE, counter, 2), 1, 1).
+
+-spec cnt_read() -> integer().
+cnt_read() ->
+    counters:get(
+        ets:lookup_element(?MODULE, counter, 2), 1).
+
+-spec fails_until(integer()) -> fail() | ok.
+fails_until(X) ->
+    fails_until(X, cnt_read()).
+
+-spec fails_until(integer(), integer()) -> fail() | ok.
+fails_until(X, Curr) when X > Curr ->
+    cnt_incr(),
+    throw({fail, {Curr, X}});
+fails_until(_X, _Curr) ->
+    ok.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Test Cases
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-spec task(config()) -> ok.
+task(_Config) ->
+    ok = ktn_task:wait_for(fun() -> ok end, ok, 1, 1),
+    ok = ktn_task:wait_for(fun() -> fails_until(10) end, ok, 1, 11),
+    ok.
+
+-spec task_error(config()) -> ok.
+task_error(_Config) ->
+    {error, {timeout, {fail}}} =
+              ktn_task:wait_for(fun() -> throw({fail}) end, 1, 1, 3),
+    {error, {timeout, {fail, {10, 15}}}} =
+              ktn_task:wait_for(fun() -> fails_until(15) end, ok, 1, 11),
+    ok.

--- a/test/ktn_task_SUITE.erl
+++ b/test/ktn_task_SUITE.erl
@@ -7,8 +7,8 @@
         ]).
 
 -export([
-         task/1,
-         task_error/1
+         wait_for/1,
+         wait_for_error/1
         ]).
 
 -define(EXCLUDED_FUNS,
@@ -69,16 +69,16 @@ fails_until(_X, _Curr) ->
 %% Test Cases
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec task(config()) -> ok.
-task(_Config) ->
+-spec wait_for(config()) -> ok.
+wait_for(_Config) ->
     ok = ktn_task:wait_for(fun() -> ok end, ok, 1, 1),
-    ok = ktn_task:wait_for(fun() -> fails_until(10) end, ok, 1, 11),
+    ok = ktn_task:wait_for(fun() -> fails_until(10) end, ok, 0, 11),
     ok.
 
--spec task_error(config()) -> ok.
-task_error(_Config) ->
+-spec wait_for_error(config()) -> ok.
+wait_for_error(_Config) ->
     {error, {timeout, {fail}}} =
-              ktn_task:wait_for(fun() -> throw({fail}) end, 1, 1, 3),
+              ktn_task:wait_for(fun() -> throw({fail}) end, ok, 0, 3),
     {error, {timeout, {fail, {10, 15}}}} =
-              ktn_task:wait_for(fun() -> fails_until(15) end, ok, 1, 11),
+              ktn_task:wait_for(fun() -> fails_until(15) end, ok, 0, 11),
     ok.


### PR DESCRIPTION
This PR adds tests for `ktn_task/4` in two ways:

- Basic ok and throw for a function's single execution.
- Based on a counter on an ets table, ok and throw after a repeated number of executions.

Not testing `ktn_task/2` because it hangs for 2 secs.